### PR TITLE
Ensure to keep the size (at least with even dimensions) when saving

### DIFF
--- a/magica/voxelobject.go
+++ b/magica/voxelobject.go
@@ -145,6 +145,12 @@ func (v *VoxelObject) Split(size int) scenegraph.Node {
 					}
 				})
 
+				if x == objectsX-1 && y == objectsY-1 && z == objectsZ-1 {
+					maxX = v.Size.X - x*size
+					maxY = v.Size.Y - y*size
+					maxZ = v.Size.Z - z*size
+				}
+
 				// Make all sizes divisible by 2
 				maxX = maxX + (maxX % 2)
 				maxY = maxY + (maxY % 2)


### PR DESCRIPTION
Problem: if model dimensions are at or greater than `256*256*256`, when Gandalf (and therefore Cargopositor) saves the model, it becomes cropped and changes size.

This problem, of course, affects the alignment of any further rendering, and makes further operations (in particular, the `repeat` operator of Cargopositor) hard to use.

This patch ensures that the model dimensions do not change. I did not change the assumption that the model dimension has to be even numbers though.